### PR TITLE
Share ui

### DIFF
--- a/app/assets/stylesheets/controllers/welcome.scss
+++ b/app/assets/stylesheets/controllers/welcome.scss
@@ -1,6 +1,10 @@
 .welcome {
   min-height: 100vh;
 
+  background-repeat: no-repeat;
+  background-size: cover;
+  background-position: center center;
+
   nav {
     background: none;
     box-shadow: none;

--- a/app/controllers/concerns/message_manager.rb
+++ b/app/controllers/concerns/message_manager.rb
@@ -63,7 +63,7 @@ module MessageManager
         passengers.each do |passenger|
           notifier.notify(passenger,
             ellipsize("#{sender} says: \"", message.content,
-                      "\" See #{share_ride_url(ride)} for details"))
+                      "\" See #{short_passenger_ride_url(ride)} for details"))
         end
       else
         drivers.each do |driver|

--- a/app/controllers/driver/rides_controller.rb
+++ b/app/controllers/driver/rides_controller.rb
@@ -55,7 +55,7 @@ class Driver::RidesController < Driver::BaseController
         @ride.notified_passengers.each do |passenger|
           notifier.notify(passenger,
             "Your driver made a change to your ride. " +
-            "See #{share_ride_url(@ride)} for details")
+            "See #{short_passenger_ride_url(@ride)} for details")
         end
 
         format.html { redirect_to driver_ride_path(@ride),
@@ -103,7 +103,7 @@ class Driver::RidesController < Driver::BaseController
         @ride.notified_passengers.each do |passenger|
           notifier.notify(passenger,
             "A driver (#{current_user.email}) just accepted your ride request. " +
-            "See #{share_ride_url(@ride)} for details.")
+            "See #{short_passenger_ride_url(@ride)} for details.")
         end
 
         format.html { redirect_to driver_ride_path(@ride),
@@ -131,7 +131,7 @@ class Driver::RidesController < Driver::BaseController
         @ride.notified_passengers.each do |passenger|
           notifier.notify(passenger,
             "Your driver (#{current_user.email}) will no longer be driving for you! " +
-            "See #{share_ride_url(@ride)} for details.")
+            "See #{short_passenger_ride_url(@ride)} for details.")
         end
 
         format.html { redirect_to driver_rides_path,

--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -1,4 +1,11 @@
 class WelcomeController < ApplicationController
   def index
   end
+
+  def share
+    @ride = Ride.find params[:ride_id]
+    unless @ride.driver.nil?
+      redirect_to passenger_ride_path(@ride)
+    end
+  end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,13 +1,14 @@
 <!DOCTYPE html>
-<html>
+<html lang="en" prefix="og: http://ogp.me/ns#">
   <head>
     <meta charset="utf-8">
-    <title>Ride Board</title>
+    <title>RideBoard.app</title>
 
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 
+    <meta property="og:site_name" content="RideBoard.app" />
     <meta property="fb:app_id" content="2479083255670794" />
 
     <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,6 +9,7 @@
     <%= csp_meta_tag %>
 
     <meta property="og:site_name" content="RideBoard.app" />
+    <meta property="og:image" content="<%= image_path 'background.jpg' %>" />
     <meta property="fb:app_id" content="2479083255670794" />
 
     <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,6 +8,8 @@
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 
+    <meta property="fb:app_id" content="2479083255670794" />
+
     <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
 

--- a/app/views/passenger/rides/show.html.erb
+++ b/app/views/passenger/rides/show.html.erb
@@ -1,16 +1,4 @@
-<% content_for :head do %>
-  <meta property="og:url"   content="<%=share_ride_url(@ride)%>" />
-  <meta property="og:type"  content="website" />
-  <% if @ride.driver.nil? %>
-    <meta property="og:title"
-          content="Requesting ride to <%=@ride.end_location.name%> on <%= @ride.start_datetime.to_s(:short_ampm) %>"/>
-  <% else %>
-    <meta property="og:title"
-          content="Offering ride to <%=@ride.end_location.name%> on <%= @ride.start_datetime.to_s(:short_ampm) %>"/>
-  <% end %>
-  <meta property="og:description"
-        content="Ride from <%= @ride.start_location.name %> to <%= @ride.end_location.name %> on <%=@ride.start_datetime.to_s(:short_ampm)%>." />
-<% end %>
+<%= render "rides/ride_og_meta", ride: @ride %>
 
 <% content_for :body do %>
   <!-- Load Facebook SDK for JavaScript -->

--- a/app/views/passenger/rides/show.html.erb
+++ b/app/views/passenger/rides/show.html.erb
@@ -4,15 +4,12 @@
   <% if @ride.driver.nil? %>
     <meta property="og:title"
           content="Requesting ride to <%=@ride.end_location.name%> on <%= @ride.start_datetime.to_s(:short_ampm) %>"/>
-    <meta property="og:description"
-          content="I need a driver to take me from <%= @ride.start_location.name %> to <%= @ride.end_location.name %> on <%=@ride.start_datetime.to_s(:short_ampm)%>. Please click on this link to drive or join." />
   <% else %>
     <meta property="og:title"
           content="Offering ride to <%=@ride.end_location.name%> on <%= @ride.start_datetime.to_s(:short_ampm) %>"/>
-    <meta property="og:description"
-          content="I am riding from <%= @ride.start_location.name %> to <%= @ride.end_location.name %> on <%=@ride.start_datetime.to_s(:short_ampm)%>. Please click on this link to join." />
   <% end %>
-  <meta property="fb:app_id" content="2479083255670794" />
+  <meta property="og:description"
+        content="Ride from <%= @ride.start_location.name %> to <%= @ride.end_location.name %> on <%=@ride.start_datetime.to_s(:short_ampm)%>." />
 <% end %>
 
 <% content_for :body do %>

--- a/app/views/rides/_ride_og_meta.html.erb
+++ b/app/views/rides/_ride_og_meta.html.erb
@@ -1,0 +1,13 @@
+<% content_for :head do %>
+  <meta property="og:url"   content="<%=share_ride_url(ride)%>" />
+  <meta property="og:type"  content="website" />
+  <% if ride.driver.nil? %>
+    <meta property="og:title"
+          content="Requesting ride to <%=ride.end_location.name%> on <%= ride.start_datetime.to_s(:short_ampm) %>"/>
+  <% else %>
+    <meta property="og:title"
+          content="Offering ride to <%=ride.end_location.name%> on <%= ride.start_datetime.to_s(:short_ampm) %>"/>
+  <% end %>
+  <meta property="og:description"
+        content="Ride from <%= ride.start_location.name %> to <%= ride.end_location.name %> on <%=ride.start_datetime.to_s(:short_ampm)%>." />
+<% end %>

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -2,9 +2,6 @@
   <style>
     .welcome {
       background-image: url('<%= image_path('background.jpg') %>');
-      background-repeat: no-repeat;
-      background-size: cover;
-      background-position: center center;
     }
   </style>
 <% end %>

--- a/app/views/welcome/share.html.erb
+++ b/app/views/welcome/share.html.erb
@@ -1,0 +1,52 @@
+<% content_for :head do %>
+  <meta property="og:url"   content="<%=share_ride_url(@ride)%>" />
+  <meta property="og:type"  content="website" />
+  <meta property="og:title"
+        content="Requesting ride to <%= @ride.end_location.name %> on <%= @ride.start_datetime.to_s(:short_ampm) %>"/>
+  <meta property="og:description"
+        content="Ride from <%= @ride.start_location.name %> to <%= @ride.end_location.name %> on <%=@ride.start_datetime.to_s(:short_ampm)%>." />
+
+  <style>
+    .welcome {
+      background-image: url('<%= image_path('background.jpg') %>');
+    }
+  </style>
+<% end %>
+
+<div class="welcome">
+  <nav>
+    <div class="nav-wrapper">
+      <a href="/" class="brand-logo">RideBoard.app</a>
+    </div>
+  </nav>
+
+  <div class="row container">
+    <h1 class="white-text">Ride to <%= @ride.end_location.name %></h1>
+
+    <div class="col s12 m6 l4">
+      <div class="card z-depth-3">
+        <div class="card-image">
+          <%= image_tag 'driver.jpg' %>
+          <span class="card-title">Looking to drive</span>
+        </div>
+        <div class="card-action">
+          <%= link_to "View as Driver", driver_ride_path(@ride),
+                      class: "waves-effect waves-light btn-large" %>
+        </div>
+      </div>
+    </div>
+
+    <div class="col s12 m6 l4">
+      <div class="card z-depth-3">
+        <div class="card-image">
+          <%= image_tag 'passenger.jpg' %>
+          <span class="card-title">Looking to join in</span>
+        </div>
+        <div class="card-action">
+          <%= link_to "View as Passenger", passenger_ride_path(@ride),
+                      class: "waves-effect waves-light btn-large" %>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/welcome/share.html.erb
+++ b/app/views/welcome/share.html.erb
@@ -1,11 +1,6 @@
-<% content_for :head do %>
-  <meta property="og:url"   content="<%=share_ride_url(@ride)%>" />
-  <meta property="og:type"  content="website" />
-  <meta property="og:title"
-        content="Requesting ride to <%= @ride.end_location.name %> on <%= @ride.start_datetime.to_s(:short_ampm) %>"/>
-  <meta property="og:description"
-        content="Ride from <%= @ride.start_location.name %> to <%= @ride.end_location.name %> on <%=@ride.start_datetime.to_s(:short_ampm)%>." />
+<%= render "rides/ride_og_meta", ride: @ride %>
 
+<% content_for :head do %>
   <style>
     .welcome {
       background-image: url('<%= image_path('background.jpg') %>');

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,7 @@ Rails.application.routes.draw do
   devise_for :users, path: 'account'
   resources :locations
 
-  get "/s/:id", to: redirect('/passenger/rides/%{id}'), as: :share_ride
+  get "/s/:ride_id", to: "welcome#share", as: :share_ride
   get "/d/:id", to: redirect('/driver/rides/%{id}'), as: :short_driver_ride
   get "/p/:id", to: redirect('/passenger/rides/%{id}'), as: :short_passenger_ride
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,7 @@ Rails.application.routes.draw do
 
   get "/s/:id", to: redirect('/passenger/rides/%{id}'), as: :share_ride
   get "/d/:id", to: redirect('/driver/rides/%{id}'), as: :short_driver_ride
+  get "/p/:id", to: redirect('/passenger/rides/%{id}'), as: :short_passenger_ride
 
   namespace :passenger do
     root to: "rides#index"

--- a/test/controllers/welcome_controller_test.rb
+++ b/test/controllers/welcome_controller_test.rb
@@ -7,4 +7,16 @@ class WelcomeControllerTest < ActionDispatch::IntegrationTest
     get root_url
     assert_response :success
   end
+
+  test "should redirect rides with drivers" do
+    ride = rides(:driver_created)
+    get share_ride_url(ride)
+    assert_redirected_to passenger_ride_url(ride)
+  end
+
+  test "should render a page for rides without drivers" do
+    ride = rides(:driverless)
+    get share_ride_url(ride)
+    assert_response :success
+  end
 end


### PR DESCRIPTION
Resolves #53 

# Changes

- Created a distinct sharing page that gives you the option to choose an app to view a ride with
- Notifications now use a different shortened passenger URL

# Manual Testing

1. Make sure notifications send the right kinds of shortened URLs for the passenger app
2. Share a ride with a driver, look at the open graph metadata and make sure it lines up with what you would imagine
3. Make sure it redirects to the passenger app automatically
4. Share a ride with no driver, look at the open graph metadata
5. Make sure it lets you choose which app
