### PR TITLE
Remove end datetime and clean up ride list

### DIFF
--- a/app/assets/javascripts/init-elements.js
+++ b/app/assets/javascripts/init-elements.js
@@ -67,10 +67,8 @@ var MaterialDateTimePicker = {
 document.addEventListener("turbolinks:load", function() {
   M.AutoInit();
   var start_datetime = document.getElementById('ride_start_datetime');
-  var end_datetime = document.getElementById('ride_end_datetime');
-  if(start_datetime && end_datetime){
-        MaterialDateTimePicker.create(start_datetime);
-        MaterialDateTimePicker.create(end_datetime);
+  if(start_datetime){
+    MaterialDateTimePicker.create(start_datetime);
   }
 });
 

--- a/app/assets/stylesheets/controllers/rides.scss
+++ b/app/assets/stylesheets/controllers/rides.scss
@@ -4,6 +4,26 @@
 
 @import "theme";
 
+.rb-rides {
+  &__heading {
+    @include large-heading();
+    @include section-margin();
+    @include section-padding();
+  }
+
+  &__prompt {
+    text-align: center;
+  }
+}
+
+.rb-ride-thumbnail {
+  color: currentColor;
+
+  &::hover {
+    background-color: $light-grey;
+  }
+}
+
 .rb-ride-nav-links {
   @include section-margin();
   @include section-padding();
@@ -21,6 +41,7 @@
 
 .rb-ride-locations {
   @include section-margin();
+  @include section-border();
 
   padding: 0;
   display: flex;
@@ -30,7 +51,6 @@
 
 .rb-ride-location {
   @include section-padding();
-  @include section-border();
 
   flex: 1;
   margin: 0;

--- a/app/views/driver/me/show.html.erb
+++ b/app/views/driver/me/show.html.erb
@@ -2,7 +2,5 @@
   <%= link_to 'Notification Preferences', driver_notify_path, class: 'btn' %>
 <% end %>
 
-<%= render "me/ride_list",
-           upcoming_rides: @upcoming_rides, past_rides: @past_rides,
-           ride_path: -> (ride) {driver_ride_path(ride)},
-           edit_path: -> (ride) {edit_driver_ride_path(ride)} %>
+<%= render "me/ride_list", app: :driver,
+           upcoming_rides: @upcoming_rides, past_rides: @past_rides %>

--- a/app/views/driver/rides/_form.html.erb
+++ b/app/views/driver/rides/_form.html.erb
@@ -4,22 +4,17 @@
 
   <div class="input-field">
     <%= form.collection_select :start_location_id, Location.all, :id, :name, prompt: true %>
-    <%= form.label :start_location %>
+    <%= form.label :start_location, "Pickup Location" %>
   </div>
 
   <div class="input-field">
     <%= form.text_field :start_datetime, default: Time.zone.now, class:"datetimepicker"%>
-    <%= form.label :start_datetime %>
+    <%= form.label :start_datetime, "Pickup Time" %>
   </div>
 
   <div class="input-field">
     <%= form.collection_select :end_location_id, Location.all, :id, :name, prompt: true %>
-    <%= form.label :end_location %>
-  </div>
-
-  <div class="input-field">
-    <%= form.text_field :end_datetime, class:"datetimepicker", default: Time.zone.now %>
-    <%= form.label :end_datetime %>
+    <%= form.label :end_location, "Destination" %>
   </div>
 
   <div class="input-field">

--- a/app/views/driver/rides/index.html.erb
+++ b/app/views/driver/rides/index.html.erb
@@ -1,26 +1,15 @@
-<h1>Rides</h1>
+<% unless @rides.empty? %>
+  <section>
+    <h1 class="rb-rides__heading">Requested Rides</h1>
 
-<table>
-  <thead>
-    <tr>
-      <th>Start location</th>
-      <th>Start datetime</th>
-      <th>End location</th>
-      <th>End datetime</th>
-      <th>Driver</th>
-      <th colspan="3"></th>
-    </tr>
-  </thead>
-
-  <tbody>
     <% @rides.each do |ride| %>
-      <%= render "rides/ride_thumbnail", ride: ride,
-                 ride_path: driver_ride_path(ride),
-                 edit_path: edit_driver_ride_path(ride) %>
+      <%= render "rides/ride_thumbnail", ride: ride, app: :driver %>
     <% end %>
-  </tbody>
-</table>
+  </section>
+<% end %>
 
-<br>
+<div class="rb-rides__prompt">
+  <p>Don't see what you're looking for?</p>
 
-<%= link_to 'New Ride', new_driver_ride_path %>
+  <%= link_to 'Offer a Ride', new_driver_ride_path, class: "btn" %>
+</div>

--- a/app/views/me/_ride_list.html.erb
+++ b/app/views/me/_ride_list.html.erb
@@ -1,49 +1,19 @@
-<section id="upcoming-rides">
-  <h2>Upcoming Rides</h2>
+<% unless @upcoming_rides.empty? %>
+  <section id="upcoming-rides">
+    <h2 class="rb-rides__heading">Upcoming Rides</h1>
 
-  <table>
-    <thead>
-      <tr>
-        <th>Start location</th>
-        <th>Start datetime</th>
-        <th>End location</th>
-        <th>End datetime</th>
-        <th>Driver</th>
-        <th colspan="3"></th>
-      </tr>
-    </thead>
+    <% upcoming_rides.each do |ride| %>
+      <%= render "rides/ride_thumbnail", ride: ride, app: app %>
+    <% end %>
+  </section>
+<% end %>
 
-    <tbody>
-      <% upcoming_rides.each do |ride| %>
-        <%= render "rides/ride_thumbnail", ride: ride,
-                  ride_path: ride_path[ride],
-                  edit_path: edit_path[ride] %>
-      <% end %>
-    </tbody>
-  </table>
-</section>
+<% unless @past_rides.empty? %>
+  <section id="past-rides">
+    <h2 class="rb-rides__heading">Past Rides</h1>
 
-<section id="past-rides">
-  <h2>Past Rides</h2>
-
-  <table>
-    <thead>
-      <tr>
-        <th>Start location</th>
-        <th>Start datetime</th>
-        <th>End location</th>
-        <th>End datetime</th>
-        <th>Driver</th>
-        <th colspan="3"></th>
-      </tr>
-    </thead>
-
-    <tbody>
-      <% past_rides.each do |ride| %>
-        <%= render "rides/ride_thumbnail", ride: ride,
-                  ride_path: ride_path[ride],
-                  edit_path: edit_path[ride] %>
-      <% end %>
-    </tbody>
-  </table>
-</section>
+    <% past_rides.each do |ride| %>
+      <%= render "rides/ride_thumbnail", ride: ride, app: app %>
+    <% end %>
+  </section>
+<% end %>

--- a/app/views/passenger/me/show.html.erb
+++ b/app/views/passenger/me/show.html.erb
@@ -2,7 +2,5 @@
   <%= link_to 'Notification Preferences', passenger_notify_path, class: 'btn' %>
 <% end %>
 
-<%= render "me/ride_list",
-           upcoming_rides: @upcoming_rides, past_rides: @past_rides,
-           ride_path: -> (ride) {passenger_ride_path(ride)},
-           edit_path: -> (ride) {edit_passenger_ride_path(ride)} %>
+<%= render "me/ride_list", app: :passenger,
+           upcoming_rides: @upcoming_rides, past_rides: @past_rides %>

--- a/app/views/passenger/rides/_form.html.erb
+++ b/app/views/passenger/rides/_form.html.erb
@@ -4,22 +4,17 @@
 
   <div class="input-field">
     <%= form.collection_select :start_location_id, Location.all, :id, :name, prompt: true %>
-    <%= form.label :start_location %>
+    <%= form.label :start_location, "Pickup Location" %>
   </div>
 
   <div class="input-field">
     <%= form.text_field :start_datetime, default: Time.zone.now, class:"datetimepicker"%>
-    <%= form.label :start_datetime %>
+    <%= form.label :start_datetime, "Pickup Time" %>
   </div>
 
   <div class="input-field">
     <%= form.collection_select :end_location_id, Location.all, :id, :name, prompt: true %>
-    <%= form.label :end_location %>
-  </div>
-
-  <div class="input-field">
-    <%= form.text_field :end_datetime, class:"datetimepicker", default: Time.zone.now %>
-    <%= form.label :end_datetime %>
+    <%= form.label :end_location, "Destination" %>
   </div>
 
   <div class="actions">

--- a/app/views/passenger/rides/index.html.erb
+++ b/app/views/passenger/rides/index.html.erb
@@ -1,55 +1,25 @@
-<h1>Rides</h1>
+<% unless @available_rides.empty? %>
+  <section id="available-rides">
+    <h1 class="rb-rides__heading">Rides with Drivers</h1>
 
-<section id="available-rides">
-  <h2>Available Rides with Drivers</h2>
+    <% @available_rides.each do |ride| %>
+      <%= render "rides/ride_thumbnail", ride: ride, app: :passenger %>
+    <% end %>
+  </section>
+<% end %>
 
-  <table>
-    <thead>
-      <tr>
-        <th>Start location</th>
-        <th>Start datetime</th>
-        <th>End location</th>
-        <th>End datetime</th>
-        <th>Driver</th>
-        <th colspan="3"></th>
-      </tr>
-    </thead>
+<% unless @other_rides.empty? %>
+  <section id="other-rides">
+    <h1 class="rb-rides__heading">Others Requested Rides</h1>
 
-    <tbody>
-      <% @available_rides.each do |ride| %>
-        <%= render "rides/ride_thumbnail", ride: ride,
-                   ride_path: passenger_ride_path(ride),
-                   edit_path: edit_passenger_ride_path(ride) %>
-      <% end %>
-    </tbody>
-  </table>
-</section>
+    <% @other_rides.each do |ride| %>
+      <%= render "rides/ride_thumbnail", ride: ride, app: :passenger %>
+    <% end %>
+  </section>
+<% end %>
 
-<section id="other-rides">
-  <h2>Other People Requested Rides</h2>
+<div class="rb-rides__prompt">
+  <p>Don't see what you're looking for?</p>
 
-  <table>
-    <thead>
-      <tr>
-        <th>Start location</th>
-        <th>Start datetime</th>
-        <th>End location</th>
-        <th>End datetime</th>
-        <th>Driver</th>
-        <th colspan="3"></th>
-      </tr>
-    </thead>
-
-    <tbody>
-      <% @other_rides.each do |ride| %>
-        <%= render "rides/ride_thumbnail", ride: ride,
-                   ride_path: passenger_ride_path(ride),
-                   edit_path: edit_passenger_ride_path(ride) %>
-      <% end %>
-    </tbody>
-  </table>
-</section>
-
-<br>
-
-<%= link_to 'New Ride', new_passenger_ride_path %>
+  <%= link_to 'Request a Ride', new_passenger_ride_path, class: "btn" %>
+</div>

--- a/app/views/rides/_ride_thumbnail.html.erb
+++ b/app/views/rides/_ride_thumbnail.html.erb
@@ -1,13 +1,3 @@
-<tr class="ride-thumbnail">
-  <td><%= ride.start_location.name %></td>
-  <td><%= ride.start_datetime.to_s(:short_ampm) %></td>
-  <td><%= ride.end_location.name %></td>
-  <td><%= ride.end_datetime.to_s(:short_ampm) %></td>
-  <td><%= ride.driver ? user_display_name(ride.driver) : "" %></td>
-  <td><%= link_to 'Show', ride_path %></td>
-  <% if ride.authorized_editor? current_user %>
-    <td><%= link_to 'Edit', edit_path %></td>
-    <td><%= link_to 'Destroy', ride_path, method: :delete,
-                              data: { confirm: 'Are you sure?' } %></td>
-  <% end %>
-</tr>
+<%= link_to [app, ride], class: "rb-ride-thumbnail" do %>
+  <%= render "rides/ride_locations", ride: ride %>
+<% end %>

--- a/test/controllers/driver/me_controller_test.rb
+++ b/test/controllers/driver/me_controller_test.rb
@@ -5,7 +5,7 @@ class Driver::MeControllerTest < ActionDispatch::IntegrationTest
     sign_in users(:driver)
     get driver_me_url
     assert_response :success
-    assert_select "#upcoming-rides .ride-thumbnail", 2
-    assert_select "#past-rides .ride-thumbnail", 1
+    assert_select "#upcoming-rides .rb-ride-thumbnail", 2
+    assert_select "#past-rides .rb-ride-thumbnail", 1
   end
 end

--- a/test/controllers/driver/rides_controller_test.rb
+++ b/test/controllers/driver/rides_controller_test.rb
@@ -12,7 +12,7 @@ class DriverRidesControllerTest < ActionDispatch::IntegrationTest
   test "should get index showing rides without drivers" do
     get driver_rides_url
     assert_response :success
-    assert_select ".ride-thumbnail", 1
+    assert_select ".rb-ride-thumbnail", 1
   end
 
   test "should get new" do

--- a/test/controllers/passenger/me_controller_test.rb
+++ b/test/controllers/passenger/me_controller_test.rb
@@ -5,7 +5,7 @@ class Passenger::MeControllerTest < ActionDispatch::IntegrationTest
     sign_in users(:creator)
     get passenger_me_url
     assert_response :success
-    assert_select "#upcoming-rides .ride-thumbnail", 2
-    assert_select "#past-rides .ride-thumbnail", 1
+    assert_select "#upcoming-rides .rb-ride-thumbnail", 2
+    assert_select "#past-rides .rb-ride-thumbnail", 1
   end
 end

--- a/test/controllers/passenger/rides_controller_test.rb
+++ b/test/controllers/passenger/rides_controller_test.rb
@@ -11,13 +11,8 @@ class PassengerRidesControllerTest < ActionDispatch::IntegrationTest
   test "should get index showing ride groups with empty seats" do
     get passenger_rides_url
     assert_response :success
-    assert_select "#available-rides" do
-      assert_select ".ride-thumbnail", 1
-    end
-
-    assert_select "#other-rides" do
-      assert_select ".ride-thumbnail", 1
-    end
+    assert_select "#available-rides .rb-ride-thumbnail", 1
+    assert_select "#other-rides .rb-ride-thumbnail", 1
   end
 
   test "should get new" do


### PR DESCRIPTION
Resolves #32 
Resolves #39 

# Changes

- Remove end datetime from all UI
- Refresh ride list look to match details page look and feel

# Manual Testing

1. Make sure all ride lists look okay (driver/passenger versions of rides/me)
2. Be sure clicking on rides in there works
3. Make sure the date picker works for create ride page in both apps