### PR TITLE
Keep rides when all passengers and drivers leave

### DIFF
--- a/app/controllers/driver/rides_controller.rb
+++ b/app/controllers/driver/rides_controller.rb
@@ -134,14 +134,13 @@ class Driver::RidesController < Driver::BaseController
             "See #{short_passenger_ride_url(@ride)} for details.")
         end
 
-        format.html { redirect_to driver_rides_path,
+        format.html { redirect_to driver_ride_path(@ride),
                                   notice: 'You have left this ride.' }
         format.json { render :show, status: :created, location: @ride }
       else
         message = 'You have already left this ride'
-        format.html { redirect_to driver_rides_path, notice: message }
-        format.json { render json: { message: message },
-                              status: :forbidden }
+        format.html { redirect_to driver_ride_path(@ride), notice: message }
+        format.json { render json: { message: message }, status: :forbidden }
       end
     end
   end

--- a/app/controllers/passenger/rides_controller.rb
+++ b/app/controllers/passenger/rides_controller.rb
@@ -128,14 +128,13 @@ class Passenger::RidesController < Passenger::BaseController
               "See #{short_driver_ride_url(@ride)} for details.")
           end
 
-          format.html { redirect_to passenger_rides_path,
+          format.html { redirect_to passenger_ride_path(@ride),
                                     notice: 'You have left this ride.' }
           format.json { render :show, status: :created, location: @ride }
         else
           message = 'You have already left this ride'
-          format.html { redirect_to passenger_rides_path, notice: message }
-          format.json { render json: { message: message },
-                                status: :forbidden }
+          format.html { redirect_to passenger_ride_path(@ride), notice: message }
+          format.json { render json: { message: message }, status: :forbidden }
         end
       end
     end

--- a/app/models/ride.rb
+++ b/app/models/ride.rb
@@ -51,10 +51,4 @@ class Ride < ApplicationRecord
       ride.errors[:passengers] << "do not have enough seats"
     end
   end
-
-  after_save do |ride|
-    if ride.driver.nil? && ride.passengers.empty?
-      ride.destroy
-    end
-  end
 end

--- a/test/controllers/driver/rides_controller_test.rb
+++ b/test/controllers/driver/rides_controller_test.rb
@@ -66,7 +66,7 @@ class DriverRidesControllerTest < ActionDispatch::IntegrationTest
     ride = rides(:creator_created)
     delete driver_join_ride_url(ride)
     assert_nil ride.reload.driver
-    assert_redirected_to driver_rides_url
+    assert_redirected_to driver_ride_url(ride)
   end
 
   test "leaving a ride unsubscribes you" do
@@ -92,7 +92,7 @@ class DriverRidesControllerTest < ActionDispatch::IntegrationTest
     end
 
     assert_not ride.notification_subscribers.include? user
-    assert_redirected_to driver_rides_url
+    assert_redirected_to driver_ride_url(ride)
   end
 
   test "should create ride" do

--- a/test/controllers/passenger/rides_controller_test.rb
+++ b/test/controllers/passenger/rides_controller_test.rb
@@ -90,14 +90,16 @@ class PassengerRidesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should leave a ride" do
-    sign_in users(:creator)
+    user = users(:creator)
+    ride = rides(:creator_created)
+    sign_in user
 
     assert_difference -> {SeatAssignment.count}, -1 do
-      delete passenger_join_ride_url(rides(:creator_created))
+      delete passenger_join_ride_url(ride)
     end
 
-    assert_not rides(:creator_created).passengers.include? users(:creator)
-    assert_redirected_to passenger_rides_url
+    assert_not ride.passengers.include? user
+    assert_redirected_to passenger_ride_url(ride)
   end
 
   test "leaving a ride unsubscribes you" do
@@ -111,14 +113,16 @@ class PassengerRidesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "can leave a ride you aren't subscribed to" do
-    sign_in users(:creator)
+    user = users(:creator)
+    ride = rides(:driverless)
+    sign_in user
 
     assert_no_difference -> {RideNotificationSubscription.count} do
-      delete passenger_join_ride_url(rides(:driverless))
+      delete passenger_join_ride_url(ride)
     end
 
-    assert_not rides(:driverless).notification_subscribers.include? users(:creator)
-    assert_redirected_to passenger_rides_url
+    assert_not ride.notification_subscribers.include? user
+    assert_redirected_to passenger_ride_url(ride)
   end
 
   test "should create ride" do

--- a/test/models/ride_test.rb
+++ b/test/models/ride_test.rb
@@ -67,15 +67,19 @@ class RideTest < ActiveSupport::TestCase
     assert_not rides(:driver_created).valid?
   end
 
-  test "ride destorys itself when it has no more driver or passengers" do
-    assert_difference -> {Ride.count}, -1 do
-      rides(:driverless).passengers = []
-      rides(:driverless).save
+  test "ride stays when it has no more drivers or passengers" do
+    no_driver = rides(:driverless)
+    no_passengers = rides(:past_with_driver)
+    assert no_passengers.passengers.empty?
+
+    assert_no_difference -> {Ride.count} do
+      no_driver.passengers = []
+      no_driver.save
     end
 
-    assert_difference -> {Ride.count}, -1 do
-      rides(:past_with_driver).driver = nil
-      rides(:past_with_driver).save
+    assert_no_difference -> {Ride.count} do
+      no_passengers.driver = nil
+      no_passengers.save
     end
   end
 end


### PR DESCRIPTION
Resolves #52 

# Changes

- Rides persist even when all drivers and passengers are gone

# Manual Testing

1. Sign in as a driver/passenger
2. Create a ride
3. Leave it.  It should remain
4. Join again