### PR TITLE
Remove yarn integrity tests

### DIFF
--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -17,7 +17,5 @@ jobs:
         run: docker-compose build
       - name: Initialize database
         run: docker-compose run web bin/initialize.sh
-      - name: Run tests
+      - name: Run ruby tests
         run: docker-compose run web bin/test.sh --ruby
-      - name: Yarn integrity check
-        run: docker-compose run web bin/test.sh --yarn-integrity

--- a/bin/test.sh
+++ b/bin/test.sh
@@ -3,7 +3,6 @@
 SCRIPT_NAME="test.sh"
 
 RUBY_TESTS=false
-CHECK_YARN_INTEGRETY=false
 HELP=false
 
 # Parse command line args
@@ -13,10 +12,6 @@ do
     key="$1"
 
     case $key in
-        -Y|--yarn-integrity)
-            CHECK_YARN_INTEGRETY=true
-            shift # past argument
-            ;;
         -R|--ruby)
             RUBY_TESTS=true
             shift # past argument
@@ -44,7 +39,6 @@ if $HELP ; then
     echo "$SCRIPT_NAME [no parameters]"
     echo "  -h or --help           Print this message"
     echo "  -R or --ruby           Run ruby tests"
-    echo "  -Y or --yarn-integrity Run yarn integrity check"
     echo
     echo "Note: calling this script with no options will run all"
     echo "tests. Calling this script with any subset of the tests will"
@@ -54,19 +48,11 @@ fi
 
 EXIT_STATUS="0"
 
-if $RUBY_TESTS || ! $CHECK_YARN_INTEGRETY ; then
+if $RUBY_TESTS || true; then
     echo
     echo "Running ruby tests..."
     echo
     rake test || \
-        EXIT_STATUS="1"
-fi
-
-if $CHECK_YARN_INTEGRETY || ! $RUBY_TESTS ; then
-    echo
-    echo "Running yarn integrity check..."
-    echo
-    yarn check --integrity || \
         EXIT_STATUS="1"
 fi
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -45,7 +45,7 @@ Rails.application.configure do
   config.action_mailer.raise_delivery_errors = true
 
   config.action_mailer.perform_caching = false
-  
+
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log
 
@@ -70,4 +70,7 @@ Rails.application.configure do
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
 
+  # Turn off webpacker yarn integrity check - this is deprecated anyways:
+  # https://github.com/yarnpkg/rfcs/pull/106
+  config.webpacker.check_yarn_integrity = false
 end


### PR DESCRIPTION
They have been deprecated by yarn:
https://github.com/yarnpkg/rfcs/pull/106

Resolves #104 

# Changes

- Yarn check is no longer a part of the project in any way, shape, or form
